### PR TITLE
Implement optimistic locking

### DIFF
--- a/http/create.go
+++ b/http/create.go
@@ -15,7 +15,7 @@ func create(store jstore.JStore, extract BodyExtractor, withLinks WithLinks, url
 			return
 		}
 
-		err = store.Marshal(entity, jstore.ID(r.Project, r.DocumentType, id))
+		_, err = store.Marshal(entity, jstore.NewID(r.Project, r.DocumentType, id))
 
 		if err != nil {
 			w.SendError(err)

--- a/http/delete_test.go
+++ b/http/delete_test.go
@@ -30,7 +30,7 @@ func Test_Delete_Success(t *testing.T) {
 		nullWithLinks,
 		documentTypes,
 	)
-	err := store.Marshal(TestEntity{Message: "hello world"}, jstore.ID("project", "entity", "id"))
+	_, err := store.Marshal(TestEntity{Message: "hello world"}, jstore.NewID("project", "entity", "id"))
 	require.NoError(t, err)
 
 	response := deleteRequest(router, "http://test/project/entity/id")

--- a/http/get_test.go
+++ b/http/get_test.go
@@ -30,7 +30,7 @@ func Test_Get_Success(t *testing.T) {
 		},
 		documentTypes,
 	)
-	err := store.Marshal(TestEntity{Message: "hello world"}, jstore.ID("project", "entity", "id"))
+	_, err := store.Marshal(TestEntity{Message: "hello world"}, jstore.NewID("project", "entity", "id"))
 	require.NoError(t, err)
 
 	response := getRequest(router, "http://test/project/entity/id")

--- a/http/list_test.go
+++ b/http/list_test.go
@@ -32,9 +32,9 @@ func Test_List_Success(t *testing.T) {
 		},
 		documentTypes,
 	)
-	store.Marshal(TestEntity{Message: "hello world"}, jstore.ID("project", "entity", "earth"))
-	store.Marshal(TestEntity{Message: "hello saturn"}, jstore.ID("project", "entity", "saturn"))
-	store.Marshal(TestEntity{Message: "hello mars"}, jstore.ID("project", "entity", "mars"))
+	store.Marshal(TestEntity{Message: "hello world"}, jstore.NewID("project", "entity", "earth"))
+	store.Marshal(TestEntity{Message: "hello saturn"}, jstore.NewID("project", "entity", "saturn"))
+	store.Marshal(TestEntity{Message: "hello mars"}, jstore.NewID("project", "entity", "mars"))
 
 	response := getRequest(router, "http://test/project/entity")
 

--- a/http/update.go
+++ b/http/update.go
@@ -20,7 +20,7 @@ func update(store jstore.JStore, extract BodyExtractor, withLinks WithLinks, url
 			return
 		}
 
-		err = store.Marshal(&entity, r.EntityID())
+		_, err = store.Marshal(&entity, r.EntityID())
 
 		if err != nil {
 			w.SendError(err)

--- a/http/update_test.go
+++ b/http/update_test.go
@@ -31,7 +31,7 @@ func Test_Update_Success(t *testing.T) {
 		nullWithLinks,
 		documentTypes,
 	)
-	err := store.Marshal(TestEntity{Message: "hello world"}, jstore.ID("project", "entity", "id"))
+	_, err := store.Marshal(TestEntity{Message: "hello world"}, jstore.NewID("project", "entity", "id"))
 	require.NoError(t, err)
 
 	response := putRequest(router, "http://test/project/entity/id", `{"message":"hello saturn"}`)

--- a/http/wrapper.go
+++ b/http/wrapper.go
@@ -21,7 +21,7 @@ type Request struct {
 }
 
 func (request *Request) EntityID() jstore.EntityID {
-	return jstore.EntityID{request.Project, request.DocumentType, request.ID}
+	return jstore.NewID(request.Project, request.DocumentType, request.ID)
 }
 
 func (request *Request) UnmarshalBody(obj interface{}) error {


### PR DESCRIPTION
Extend the interfaces to allow stores to implement optimistic locking.

`EntityID` exposes the `Version` of a stored document. If the version is provided to a operations that writes to the store it should be checked by it and if the check fails the wirte should be aborted by the store by returning an `jstore.OptimisticLockingError`.

The `elastic` store implements this through the mechanism provided by elasticsearch. The memory store through counting and a store global `RWLock`.