### PR TITLE
http.Expose: don't marshal pointer to entity instead of entity. this …

### DIFF
--- a/http/update.go
+++ b/http/update.go
@@ -18,7 +18,7 @@ func update(store Store, extract BodyExtractor, withLinks WithLinks, urls *URLBu
 			return
 		}
 
-		_, err = store.Marshal(&entity, r.EntityID())
+		_, err = store.Marshal(entity, r.EntityID())
 
 		if err != nil {
 			w.SendError(err)


### PR DESCRIPTION
…is also how create behaves